### PR TITLE
New menu order

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,6 +1,12 @@
 <nav id="menu">
     <ul>
         <li>
+            <a href="/" id="nav-about">
+                <img src="/images/icon/about.svg" />
+                about
+            </a>
+        </li>
+        <li>
             <a href="/features.html" id="nav-features">
                 <img src="/images/icon/features.svg" />
                 features
@@ -19,21 +25,15 @@
             </a>
         </li>
         <li>
-            <a href="/community.html" id="nav-community">
-                <img src="/images/icon/community.svg" />
-                community
-            </a>
-        </li>
-        <li>
             <a href="/news.html" id="nav-posts">
                 <img src="/images/icon/news.svg" />
                 news
             </a>
         </li>
         <li>
-            <a href="/" id="nav-about">
-                <img src="/images/icon/about.svg" />
-                about
+            <a href="/community.html" id="nav-community">
+                <img src="/images/icon/community.svg" />
+                community
             </a>
         </li>
     </ul>

--- a/css/main.css
+++ b/css/main.css
@@ -98,19 +98,19 @@ nav {
       }
 
       #nav-features {
-          background: rgba(111, 95, 93, .6);
-      }
-
-      #nav-source {
           background: rgba(131, 93, 91, .6);
       }
 
-      #nav-documentation {
+      #nav-source {
           background: rgba(162, 107, 97, .6);
       }
 
-      #nav-community {
+      #nav-documentation {
           background: rgba(227, 143, 113, .6);
+      }
+
+      #nav-community {
+          background: rgba(252, 218, 186, .6);
       }
 
       #nav-posts {
@@ -118,7 +118,7 @@ nav {
       }
 
       #nav-about {
-          background: rgba(252, 218, 186, .6);
+          background: rgba(111, 95, 93, .6);
       }
 
 #body { }


### PR DESCRIPTION
Instead of :
- features
- source
- documentation
- community
- news
- about

We use this order :
- about
- features
- source
- documentation
- news
- community

Why :
- about : it sends to the homepage of the website. currently that's the features page who's on first. It shouldn't be the case. That's on the upper left corner of the screen. The features page is a very important page. We want users to clic on it. If we left it on the upper left corner it won't be seen. People are used to to a logo here. So The homepage link seens good in that place (that's just a few lines in that page, and people are are used to go back to the home from clicking to this position).
- community : moved at the end to avoid news to be at this position. the end of a menu is generally used for credits (to it will be the case), and is will be less noticed than the rest of the menu : we don't whant to for the news item.

Before : 
![before](https://cloud.githubusercontent.com/assets/320372/12212103/c2689ea0-b666-11e5-9640-9a38d096bf8a.png)

After : 
![after](https://cloud.githubusercontent.com/assets/320372/12212105/ce6f4e24-b666-11e5-9393-664f6f0dabdc.png)
