### PR TITLE
add page title in title tag

### DIFF
--- a/_layouts/static.html
+++ b/_layouts/static.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>atoum, the modern, simple and intuitive PHP test framework</title>
+    <title>{% if page.title %}{{ page.title }} - {% endif %}atoum, the modern, simple and intuitive PHP test framework</title>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta http-equiv="content-type" content="text/javascript; charset=utf-8" />
     <meta http-equiv="content-type" content="text/css; charset=utf-8" />


### PR DESCRIPTION
like that the title will be
`Features - atoum, the modern, simple and intuitive PHP test framework`
instead of just
`atoum, the modern, simple and intuitive PHP test framework`

(it will be the same for blog posts).

fixes #33 
