### PR TITLE
Replace "pygment" highlight with "rouge"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: Atoum's website
-highlighter: pygments
+highlighter: rouge
 timezone: Europe/Paris
 future: true
 exclude:


### PR DESCRIPTION
Replace "pygments" highlighter to "[rouge](https://help.github.com/articles/using-syntax-highlighting-on-github-pages/)", that seems to be the default github page highlighter.

Fix #37 
