### PR TITLE
Fix license link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
     <p>
         atoum is the creation of Frédéric Hardy, all rights reserved.
         See
-        <a href="https://raw.githubusercontent.com/atoum/atoum/master/COPYING">the license</a>,
+        <a href="https://raw.githubusercontent.com/atoum/atoum/master/LICENSE">the license</a>,
         <a href="https://twitter.com/atoum_org/">Twitter</a> and
         <a href="https://github.com/atoum/">Github</a>. <a href="http://overview.atoum.org/">Status page</a>.
     </p>


### PR DESCRIPTION
The license link in footer was targeting an unexisting file.